### PR TITLE
Nonlinear decay curve, VOT, housekeeping

### DIFF
--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -23,8 +23,8 @@ PinkTromboneAudioProcessorEditor::PinkTromboneAudioProcessorEditor (PinkTrombone
 	tractUI.setSize(400, 300);
 	addAndMakeVisible(&tractUI);
 	
-	tongueX.setSliderStyle (Slider::Rotary);
-	tongueX.setRotaryParameters(2*M_PI, 0.1, true);
+	tongueX.setSliderStyle (Slider::RotaryVerticalDrag);
+	tongueX.setRotaryParameters(M_PI, 3*M_PI + 0.1, true);
 	tongueX.setRange(0.0, 1.0, 0.01);
 	tongueX.setTextBoxStyle (Slider::NoTextBox, false, 90, 0);
 	tongueX.setPopupDisplayEnabled (true, true, this);
@@ -33,8 +33,8 @@ PinkTromboneAudioProcessorEditor::PinkTromboneAudioProcessorEditor (PinkTrombone
 	addAndMakeVisible (&tongueX);
 	tongueX.addListener(this);
 	
-	tongueY.setSliderStyle (Slider::Rotary);
-	tongueY.setRotaryParameters(2*M_PI, 0.1, true);
+	tongueY.setSliderStyle (Slider::RotaryVerticalDrag);
+	tongueY.setRotaryParameters(M_PI, 3*M_PI + 0.1, true);
 	tongueY.setRange(0.0, 1.0, 0.01);
 	tongueY.setTextBoxStyle (Slider::NoTextBox, false, 90, 0);
 	tongueY.setPopupDisplayEnabled (true, true, this);
@@ -43,8 +43,8 @@ PinkTromboneAudioProcessorEditor::PinkTromboneAudioProcessorEditor (PinkTrombone
 	addAndMakeVisible (&tongueY);
 	tongueY.addListener(this);
 	
-	constrictionX.setSliderStyle (Slider::Rotary);
-	constrictionX.setRotaryParameters(2*M_PI, 0.1, true);
+	constrictionX.setSliderStyle (Slider::RotaryVerticalDrag);
+	constrictionX.setRotaryParameters(M_PI, 3*M_PI + 0.1, true);
 	constrictionX.setRange(0.0, 1.0, 0.01);
 	constrictionX.setTextBoxStyle (Slider::NoTextBox, false, 90, 0);
 	constrictionX.setPopupDisplayEnabled (true, true, this);
@@ -53,29 +53,18 @@ PinkTromboneAudioProcessorEditor::PinkTromboneAudioProcessorEditor (PinkTrombone
 	addAndMakeVisible (&constrictionX);
 	constrictionX.addListener(this);
 	
-	constrictionY.setSliderStyle (Slider::Rotary);
-	constrictionY.setRotaryParameters(2*M_PI, 0.1, true);
+	constrictionY.setSliderStyle (Slider::RotaryVerticalDrag);
+	constrictionY.setRotaryParameters(M_PI, 3*M_PI + 0.1, true);
 	constrictionY.setRange(0.0, 1.0, 0.01);
 	constrictionY.setTextBoxStyle (Slider::NoTextBox, false, 90, 0);
 	constrictionY.setPopupDisplayEnabled (true, true, this);
-	constrictionY.setTextValueSuffix (" Constriction Diameter");
+	constrictionY.setTextValueSuffix (" Rest Diameter");
 	constrictionY.setValue(1.0);
 	addAndMakeVisible (&constrictionY);
 	constrictionY.addListener(this);
 	
-	constrictionEnvelopeMax.setSliderStyle (Slider::Rotary);
-	constrictionEnvelopeMax.setRotaryParameters(2*M_PI, 0.1, true);
-	constrictionEnvelopeMax.setRange(0.0, 1.0, 0.01);
-	constrictionEnvelopeMax.setSkewFactor(0.7);
-	constrictionEnvelopeMax.setTextBoxStyle (Slider::NoTextBox, false, 90, 0);
-	constrictionEnvelopeMax.setPopupDisplayEnabled (true, true, this);
-	constrictionEnvelopeMax.setTextValueSuffix (" Constriction Max");
-	constrictionEnvelopeMax.setValue(0.0);
-	addAndMakeVisible (&constrictionEnvelopeMax);
-	constrictionEnvelopeMax.addListener(this);
-	
-	VOT.setSliderStyle (Slider::Rotary);
-	VOT.setRotaryParameters(2*M_PI, 0.1, true);
+	VOT.setSliderStyle (Slider::RotaryVerticalDrag);
+	VOT.setRotaryParameters(M_PI, 3*M_PI + 0.1, true);
 	VOT.setRange(0, 0.3, 0.01);
 	VOT.setTextBoxStyle (Slider::NoTextBox, false, 90, 0);
 	VOT.setPopupDisplayEnabled (true, true, this);
@@ -84,17 +73,8 @@ PinkTromboneAudioProcessorEditor::PinkTromboneAudioProcessorEditor (PinkTrombone
 	addAndMakeVisible (&VOT);
 	VOT.addListener(this);
 	
-	attackLength.setSliderStyle (Slider::LinearHorizontal);
-	attackLength.setRange(100, 2000, 10);
-	attackLength.setTextBoxStyle (Slider::NoTextBox, false, 90, 0);
-	attackLength.setPopupDisplayEnabled (true, true, this);
-	attackLength.setTextValueSuffix (" Attack length (ms)");
-	attackLength.setValue(100);
-	addAndMakeVisible (&attackLength);
-	attackLength.addListener(this);
-	
 	decayLength.setSliderStyle (Slider::LinearHorizontal);
-	decayLength.setRange(100, 2000, 10);
+	decayLength.setRange(0, 2000, 10);
 	decayLength.setTextBoxStyle (Slider::NoTextBox, false, 90, 0);
 	decayLength.setPopupDisplayEnabled (true, true, this);
 	decayLength.setTextValueSuffix (" Decay length (ms)");
@@ -102,13 +82,26 @@ PinkTromboneAudioProcessorEditor::PinkTromboneAudioProcessorEditor (PinkTrombone
 	addAndMakeVisible (&decayLength);
 	decayLength.addListener(this);
 	
-	constrictionActive.setButtonText("Constriction Active");
-	addAndMakeVisible(&constrictionActive);
-	constrictionActive.addListener(this);
+	decayExp.setSliderStyle (Slider::LinearHorizontal);
+	decayExp.setRange(-5, 5, 1);
+	decayExp.setTextBoxStyle (Slider::NoTextBox, false, 90, 0);
+	decayExp.setPopupDisplayEnabled (true, true, this);
+	decayExp.setTextValueSuffix (" Decay exponent");
+	decayExp.setValue(1);
+	addAndMakeVisible (&decayExp);
+	decayExp.addListener(this);
 	
 	muteAudio.setButtonText("Mute");
 //	addAndMakeVisible(&muteAudio);
 	muteAudio.addListener(this);
+	
+	envelope.setButtonText("Constriction envelope");
+	addAndMakeVisible(&envelope);
+	envelope.addListener(this);
+	
+	partialConstriction.setButtonText("Partial constriction");
+	addAndMakeVisible(&partialConstriction);
+	partialConstriction.addListener(this);
 	
 	addMouseListener(this, true);
 
@@ -133,12 +126,12 @@ void PinkTromboneAudioProcessorEditor::resized()
 	tongueY.setBounds (70, 20, 70, 50);
 	constrictionX.setBounds (0, 80, 70, 50);
 	constrictionY.setBounds (70, 80, 70, 50);
-	constrictionEnvelopeMax.setBounds (0, 140, 70, 50);
-	VOT.setBounds (70, 140, 70, 50);
-	attackLength.setBounds (15, 190, 110, 50);
-	decayLength.setBounds (15, 220, 110, 50);
+	VOT.setBounds (140, 20, 70, 50);
+	decayLength.setBounds (15, 130, 110, 50);
+	decayExp.setBounds (15, 160, 110, 50);
+	envelope.setBounds(20, 200, 80, 20);
+	partialConstriction.setBounds(20, 230, 100, 20);
 	muteAudio.setBounds(170, 30, 100, 20);
-	constrictionActive.setBounds(150, 30, 100, 20);
 	tractUI.setSize(getWidth(), getHeight());
 }
 
@@ -148,13 +141,11 @@ void PinkTromboneAudioProcessorEditor::sliderValueChanged (Slider* slider)
 	processor.tongueY = tongueY.getValue();
 	processor.constrictionX = constrictionX.getValue();
 	processor.constrictionY = constrictionY.getValue();
-	processor.constrictionEnvelopeMax = constrictionEnvelopeMax.getValue()/2 + 0.5;
-	processor.attackLength = attackLength.getValue()/1000;
 	processor.decayLength = decayLength.getValue()/1000;
-	processor.UIConstrictionY = constrictionY.getValue();
+	processor.restConstrictionY = constrictionY.getValue();
 	processor.VOT = VOT.getValue();
-	processor.adsrParams.attack = attackLength.getValue()/1000;
 	processor.adsrParams.decay = decayLength.getValue()/1000;
+	processor.adsrParams.decayExp = decayExp.getValue();
 }
 
 void PinkTromboneAudioProcessorEditor::buttonClicked(Button *button) { }
@@ -162,7 +153,11 @@ void PinkTromboneAudioProcessorEditor::buttonClicked(Button *button) { }
 void PinkTromboneAudioProcessorEditor::buttonStateChanged(Button *button)
 {
 	processor.muteAudio = this->muteAudio.getToggleState();
-	processor.constrictionActive = this->constrictionActive.getToggleState();
+	processor.envelope = this->envelope.getToggleState();
+	if (partialConstriction.getToggleState())
+		processor.constrictionEnvelopeMax = 0.17;
+	else if (!partialConstriction.getToggleState())
+		processor.constrictionEnvelopeMax = 0.14;
 }
 
 void PinkTromboneAudioProcessorEditor::updateSliders()
@@ -179,11 +174,6 @@ void PinkTromboneAudioProcessorEditor::mouseDown(const juce::MouseEvent& e)
 }
 
 void PinkTromboneAudioProcessorEditor::mouseDrag(const juce::MouseEvent& e)
-{
-	this->updateSliders();
-}
-
-void PinkTromboneAudioProcessorEditor::mouseUp(const juce::MouseEvent& e)
 {
 	this->updateSliders();
 }

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -28,7 +28,6 @@ public:
     void resized() override;
 	void mouseDown(const MouseEvent& e) override;
 	void mouseDrag(const MouseEvent& e) override;
-	void mouseUp(const MouseEvent& e) override;
 
 private:
 	void sliderValueChanged (Slider* slider) override;
@@ -48,8 +47,11 @@ private:
 	Slider attackLength;
 	Slider decayLength;
 	Slider VOT;
-	ToggleButton constrictionActive;
+	Slider attackExp;
+	Slider decayExp;
 	ToggleButton muteAudio;
+	ToggleButton envelope;
+	ToggleButton partialConstriction;
 	TractUI tractUI;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (PinkTromboneAudioProcessorEditor)

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -126,7 +126,7 @@ public:
 				scaledEnvelopeVal = powf(envelopeVal, parameters.decayExp);
 			else
 				scaledEnvelopeVal = powf(envelopeVal, (-1/parameters.decayExp));
-			scaledEnvelopeVal *= (1-parameters.sustain);
+			scaledEnvelopeVal = parameters.sustain + scaledEnvelopeVal*(1-parameters.sustain);
 			return scaledEnvelopeVal;
 		}
 		else if (state == State::sustain)

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -15,6 +15,163 @@
 #include "Tract.hpp"
 #include "WhiteNoise.hpp"
 #include "Biquad.hpp"
+#include <math.h>
+
+
+class PinkTromboneADSR
+{
+public:
+	//==============================================================================
+	PinkTromboneADSR()
+	{
+		recalculateRates();
+	}
+
+	//==============================================================================
+	struct Parameters
+	{
+		Parameters() = default;
+
+		Parameters (float attackTimeSeconds,
+					float decayTimeSeconds,
+					float sustainLevel,
+					float decayExponent)
+			: attack (attackTimeSeconds),
+			  decay (decayTimeSeconds),
+			  sustain (sustainLevel),
+			  decayExp(decayExponent)
+		{
+		}
+
+		float attack = 0.1f, decay = 0.1f, sustain = 1.0f, attackExp=1.0f, decayExp=1.0f;
+	};
+
+	void setParameters (const Parameters& newParameters)
+	{
+		// need to call setSampleRate() first!
+		jassert (sampleRate > 0.0);
+
+		parameters = newParameters;
+		recalculateRates();
+	}
+
+	//==============================================================================
+	void setSampleRate (double newSampleRate) noexcept
+	{
+		jassert (newSampleRate > 0.0);
+		sampleRate = newSampleRate;
+	}
+
+	//==============================================================================
+
+	void reset() noexcept
+	{
+		envelopeVal = 0.0f;
+		state = State::idle;
+	}
+	
+	void noteOn() noexcept
+	{
+		if (attackRate > 0.0f)
+		{
+			state = State::attack;
+		}
+		else if (decayRate > 0.0f)
+		{
+			envelopeVal = 1.0f;
+			state = State::decay;
+		}
+		else
+		{
+			envelopeVal = parameters.sustain;
+			state = State::sustain;
+		}
+	}
+	
+	void noteOff() noexcept
+	{
+		if (state != State::idle)
+			reset();
+	}
+
+	//==============================================================================
+	float getNextSample() noexcept
+	{
+		float scaledEnvelopeVal;
+		
+		if (state == State::idle)
+			return 0.0f;
+
+		if (state == State::attack)
+		{
+			envelopeVal += attackRate;
+
+			if (envelopeVal >= 1.0f)
+			{
+				envelopeVal = 1.0f;
+				goToNextState();
+			}
+		}
+		else if (state == State::decay)
+		{
+			envelopeVal -= decayRate;
+
+			if (envelopeVal <= parameters.sustain)
+			{
+				envelopeVal = parameters.sustain;
+				goToNextState();
+			}
+			if (parameters.decayExp >= 0)
+				scaledEnvelopeVal = powf(envelopeVal, parameters.decayExp);
+			else
+				scaledEnvelopeVal = powf(envelopeVal, (-1/parameters.decayExp));
+			return scaledEnvelopeVal;
+		}
+		else if (state == State::sustain)
+		{
+			envelopeVal = parameters.sustain;
+		}
+
+		return envelopeVal;
+	}
+
+private:
+	//==============================================================================
+	void recalculateRates() noexcept
+	{
+		auto getRate = [] (float distance, float timeInSeconds, double sr)
+		{
+			return timeInSeconds > 0.0f ? (float) (distance / (timeInSeconds * sr)) : -1.0f;
+		};
+
+		attackRate  = getRate (1.0f, parameters.attack, sampleRate);
+		decayRate   = getRate (1.0f - parameters.sustain, parameters.decay, sampleRate);
+
+		if ((state == State::attack && attackRate <= 0.0f)
+			|| (state == State::decay && (decayRate <= 0.0f || envelopeVal <= parameters.sustain)))
+		{
+			goToNextState();
+		}
+	}
+
+	void goToNextState() noexcept
+	{
+		if (state == State::attack)
+			state = (decayRate > 0.0f ? State::decay : State::sustain);
+		else if (state == State::decay)
+			state = State::sustain;
+	}
+
+	//==============================================================================
+	enum class State { idle, attack, decay, sustain };
+
+	State state = State::idle;
+	Parameters parameters;
+
+	double sampleRate = 44100.0;
+	float envelopeVal = 0.0f, attackRate = 0.0f, decayRate = 0.0f;
+};
+
 
 //==============================================================================
 /**
@@ -67,17 +224,20 @@ public:
 	float constrictionY = 0.0;
 	float fricativeIntensity = 0.0;
 	bool muteAudio = false;
-	bool constrictionActive = false;
 	double constrictionMin = -2.0;
 	double constrictionMax = 2.0;
-	double constrictionEnvelopeMax = 0.0;
-	float attackLength = 100;
+	double constrictionEnvelopeMax = 0.57;
 	float decayLength = 100;
-	float UIConstrictionY;
+	float restConstrictionY;
 	double VOT;
+	int voicingCounter = 0;
+	bool envelope = false;
+	bool voicing;
+	double sampleRate;
 	
-	ADSR adsr;
-	ADSR::Parameters adsrParams;
+	
+	PinkTromboneADSR adsr;
+	PinkTromboneADSR::Parameters adsrParams;
 	
 	t_tractProps *getTractProps();
 
@@ -85,6 +245,8 @@ private:
     //==============================================================================
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (PinkTromboneAudioProcessor)
 	void applyConstrictionEnvelope(float sampleVal);
+	void setVoicingOn();
+	void applyVoicing();
 	t_tractProps tractProps;
 	Glottis *glottis;
 	Tract *tract;

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -19,6 +19,7 @@
 
 
 class PinkTromboneADSR
+// This class is called ADSR but does not implement release as it is not relevant to the pink trombone model
 {
 public:
 	//==============================================================================
@@ -43,7 +44,7 @@ public:
 		{
 		}
 
-		float attack = 0.1f, decay = 0.1f, sustain = 1.0f, attackExp=1.0f, decayExp=1.0f;
+		float attack = 0.1f, decay = 0.1f, sustain = 1.0f, decayExp=1.0f;
 	};
 
 	void setParameters (const Parameters& newParameters)
@@ -125,6 +126,7 @@ public:
 				scaledEnvelopeVal = powf(envelopeVal, parameters.decayExp);
 			else
 				scaledEnvelopeVal = powf(envelopeVal, (-1/parameters.decayExp));
+			scaledEnvelopeVal *= (1-parameters.sustain);
 			return scaledEnvelopeVal;
 		}
 		else if (state == State::sustain)
@@ -145,7 +147,7 @@ private:
 		};
 
 		attackRate  = getRate (1.0f, parameters.attack, sampleRate);
-		decayRate   = getRate (1.0f - parameters.sustain, parameters.decay, sampleRate);
+		decayRate   = getRate (1.0f, parameters.decay, sampleRate);
 
 		if ((state == State::attack && attackRate <= 0.0f)
 			|| (state == State::decay && (decayRate <= 0.0f || envelopeVal <= parameters.sustain)))

--- a/Source/TractUI.cpp
+++ b/Source/TractUI.cpp
@@ -50,8 +50,7 @@ void TractUI::mouseDown(const juce::MouseEvent &e)
 		this->setTongue(props, index, diameter);
 	} else {
 		this->isTongue = false;
-		if(this->processor.constrictionActive)
-			this->setConstriction(props, index, diameter);
+		this->setConstriction(props, index, diameter);
 	}
 }
 
@@ -65,28 +64,10 @@ void TractUI::mouseDrag(const juce::MouseEvent &e)
 	
 	this->getEventPosition(props, x, y, index, diameter);
 	
-	if(isTongue){
+	if(isTongue)
 		this->setTongue(props, index, diameter);
-	} else {
-		if(this->processor.constrictionActive)
-			this->setConstriction(props, index, diameter);
-	}
-}
-
-void TractUI::mouseUp(const juce::MouseEvent &e)
-{
-	double index;
-	double diameter;
-	t_tractProps *props = this->processor.getTractProps();
-	double x = e.getMouseDownX() + e.getDistanceFromDragStartX() - this->originX;
-	double y = e.getMouseDownY() + e.getDistanceFromDragStartY() - this->originY;
-	
-	this->getEventPosition(props, x, y, index, diameter);
-	
-	if(!isTongue){
-		if(this->processor.constrictionActive)
-			this->setConstriction(props, index, this->processor.constrictionMin);  //remove constriction
-	}
+	else
+		this->setConstriction(props, index, diameter);
 }
 
 void TractUI::setConstriction(t_tractProps *props, double index, double diameter)

--- a/Source/TractUI.hpp
+++ b/Source/TractUI.hpp
@@ -24,7 +24,6 @@ public:
 	
 	void mouseDown(const MouseEvent& e) override;
 	void mouseDrag(const MouseEvent& e) override;
-	void mouseUp(const MouseEvent& e) override;
 
 private:
 	void setConstriction(t_tractProps *props, double index, double diameter);


### PR DESCRIPTION
- Made dials alterable by vertical mouse drag and set 0 value to be at bottom
- Made max constriction on envelope a toggle (full/partial)
- Removed attack phase of envelope
- Added nonlinearities to decay curve
- Made envelope a toggle
- Implemented voice onset time
- Removed constriction active toggle
- Made UI alteration of constriction remain in position when mouse is lifted (OG pink trombone resets constriction when mouse is lifted, but I think this is not useful for us as pink trombo here is not constantly voicing)

Fixes #7, #8